### PR TITLE
Feature/simplified install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ To install using the Loupe Package Manager (LPM), run `lpm init` in an empty dir
 
 ### Running the HMI
 Perform the following steps:
-- In the root directory of the repo, run `npm install` from the command line. This creates the `node_modules` folder and installs packages the HMI depends on. 
-- Navigate into the `/app` folder, and run `npm install` again.
+- If you are not logged in with LPM, navigate to [Getting Started with LPM](https://loupeteam.github.io/LoupeDocs/tools/lpm/getting-started-with-lpm.html#logging-in) and copy the available token to the second line of `/app/.npmrc`, e.g:
+```
+//npm.pkg.github.com/:_authToken=<TOKEN>
+```
+If you are working in a private repository, this change can be tracked with git and not be necessary for future installs. If you are working in a public repo it is recommended to skip this step and login to LPM using the link above. 
+- Execute `installHMI.cmd` from the `/scripts` folder, to install the HMI.
 - You can then execute `runHMI.cmd` from the `/scripts` folder, and this will launch the HMI. 
 
 # Licensing

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,2 +1,2 @@
 @loupeteam:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=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
+//npm.pkg.github.com/:_authToken=

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,0 +1,2 @@
+@loupeteam:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=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

--- a/scripts/installHMI.cmd
+++ b/scripts/installHMI.cmd
@@ -1,0 +1,4 @@
+cd %~dp0\..
+call npm install 
+cd %~dp0\..\app
+call npm install


### PR DESCRIPTION
Adds a `.npmrc` file with a way to directly copy in our public lpm token and adds an installation script.

Why: Installing one of our HMIs on a customer machine is a very long and difficult process right now. By adding the `.npmrc` file we remove the need for our customers to install Python and LPM if the only thing they want to do is get the HMI running. They will not be able to use LPM in any other directories, but for final installs this is not a problem.

The added installation script provides another option to simplify the process of running `npm install` twice in two different directories. This isn't a huge speed up but it makes it significantly easier to communicate to the customer what they must do to install the HMI.